### PR TITLE
Use clone to install lib dependency in sketch compilation workflow

### DIFF
--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -63,7 +63,7 @@ jobs:
             # Install the library from the local path.
             - source-path: ./
             - name: ArduinoJson
-            - name: ESP Async WebServer
+            - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
           sketch-paths: |
             # Compile these sketches for all boards
             - examples


### PR DESCRIPTION
The "Compile Examples" GitHub Actions workflow defines the dependencies of the example sketches which must be defined before attempting their compilation.

Previously, it attempted to install [the "ESP Async WebServer" library](https://github.com/me-no-dev/ESPAsyncWebServer) via Library Manager, but the library maintainer never submitted the library to Library Manager (https://github.com/me-no-dev/ESPAsyncWebServer/issues/468) so that is not possible. Fortunately, [the `arduino/compile-sketches` GitHub Actions action](https://github.com/arduino/compile-sketches) supports installing dependencies from multiple sources, which include Git repositories.

This new configuration will cause the library to be installed from a clone of the `https://github.com/me-no-dev/ESPAsyncWebServer.git` repository, checked out to the tip of the default branch.