### PR TITLE
Rename main class, fix pre-commit hooks

### DIFF
--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -64,7 +64,6 @@ jobs:
             - source-path: ./
             - name: ArduinoJson
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
-              version: latest
           sketch-paths: |
             # Compile these sketches for all boards
             - examples

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -63,7 +63,8 @@ jobs:
             # Install the library from the local path.
             - source-path: ./
             - name: ArduinoJson
-            - name: ESP Async WebServer
+            - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
+              version: latest
           sketch-paths: |
             # Compile these sketches for all boards
             - examples

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Settings on each tab are displayed in a two-column table.
 
 <h1>Usage</h1>
 
-The main class is [`WebServer`](https://grmcdorman.github.io/esp8266_web_settings/classgrmcdorman_1_1_web_server.html). Create a single instance of this class, and then call its `add_setting_set` with lists of settings to create each panel in the web page.
+The main class is [`WebSettings`](https://grmcdorman.github.io/esp8266_web_settings/classgrmcdorman_1_1_web_settings.html). Create a single instance of this class, and then call its `add_setting_set` with lists of settings to create each panel in the web page.
 
 There are several settings classes:
 
@@ -30,9 +30,9 @@ There are several settings classes:
 * [`ToggleSetting`](https://grmcdorman.github.io/esp8266_web_settings/classgrmcdorman_1_1_toggle_setting.html). A setting containing a boolean; presented as a checkbox.
 * [`InfoSettingHtml`](https://grmcdorman.github.io/esp8266_web_settings/classgrmcdorman_1_1_info_setting_html.html). A "setting" that displays information that can be updated every 5 seconds. It can contain arbitrary HTML.
 
-Public methods in the [`WebServer`](https://grmcdorman.github.io/esp8266_web_settings/classgrmcdorman_1_1_web_server_html.html) class:
+Public methods in the [`WebSettings`](https://grmcdorman.github.io/esp8266_web_settings/classgrmcdorman_1_1_web_server_html.html) class:
 
-* `WebServer(uint16_t port = 80)`: Construct a new Web server; optionally specify the port.
+* `WebSettings(uint16_t port = 80)`: Construct a new Web server; optionally specify the port.
 * `void setup(const notify_t &on_save, const notify_t &on_restart, const notify_t &on_factory_reset)`: Set up to handle requests.
 * `void add_setting_set(const __FlashStringHelper *name, const SettingInterface::settings_list_t &setting_set);`: Add a collection of settings; creates a setting tab.
 * `void set_credentials(const String &user, const String &password)`: Set credentials for save, reset, factory reset, and upload operations.
@@ -66,9 +66,9 @@ Basic example:
 #include <ESP8266WiFi.h>
 #include <LittleFS.h>
 
-#include "grmcdorman/WebServer.h"
+#include "grmcdorman/WebSettings.h"
 
-grmcdorman::WebServer webServer;
+grmcdorman::WebSettings web_setings;
 
 #define DECLARE_INFO_SETTING(name, text) \
 static const char * PROGMEM name##_text = text; \
@@ -107,19 +107,19 @@ static bool restart_next_loop = false;
 static uint32_t restart_reset_when = 0;
 static constexpr uint32_t restart_reset_delay = 500;
 
-static void on_factory_reset(::grmcdorman::WebServer &)
+static void on_factory_reset(::grmcdorman::WebSettings &)
 {
     factory_reset_next_loop = true;
     restart_reset_when = millis();
 }
 
-static void on_restart(::grmcdorman::WebServer &)
+static void on_restart(::grmcdorman::WebSettings &)
 {
     restart_next_loop =-true;
     restart_reset_when = millis();
 }
 
-static void on_save(::grmcdorman::WebServer &)
+static void on_save(::grmcdorman::WebSettings &)
 {
     // Save your settings to flash.
 }
@@ -127,7 +127,7 @@ static void on_save(::grmcdorman::WebServer &)
 void setup()
 {
 
-    webServer.add_setting_set(F("Overview"), info_item_list);
+    web_setings.add_setting_set(F("Overview"), info_item_list);
     // Callbacks for info page.
     static const char in_ap_mode[] PROGMEM = "(In Access Pont mode)";
     static const char in_sta_mode[] PROGMEM = "(In Station mode)";
@@ -178,17 +178,17 @@ void setup()
 
     // NOTE: SoftAP capture portal is not happy about authentication. You should not
     // make this call for SoftAP mode, or handle SoftAP differently.
-    webServer.set_credentials("admin", "my update password");
+    web_setings.set_credentials("admin", "my update password");
 
     // If `on_restart` is a `nullptr`, the Restart & Upload buttons are not shown.
     // If `on_factory_reset` is a `nullptr`, the Factory Reset button is not shown.
-    webServer.setup(on_save, on_restart, on_factory_reset);
+    web_setings.setup(on_save, on_restart, on_factory_reset);
 }
 
 
 void loop()
 {
-    webServer.loop();      // This presently doesn't do anything. It is for future use.
+    web_setings.loop();      // This presently doesn't do anything. It is for future use.
 
     if (factory_reset_next_loop && millis() - restart_reset_when > restart_reset_delay)
     {

--- a/examples/SimpleWifiConfig/SimpleWifiConfig.ino
+++ b/examples/SimpleWifiConfig/SimpleWifiConfig.ino
@@ -1,5 +1,4 @@
 #include <ArduinoJson.h>
-#include <ArduinoOTA.h>
 #include <DNSServer.h>
 #include <ESP8266WiFi.h>
 #include <LittleFS.h>

--- a/examples/SimpleWifiConfig/SimpleWifiConfig.ino
+++ b/examples/SimpleWifiConfig/SimpleWifiConfig.ino
@@ -5,17 +5,17 @@
 #include <LittleFS.h>
 #include <WString.h>
 
-#include <grmcdorman/WebServer.h>
+#include <grmcdorman/WebSettings.h>
 
 // Forward declarations
 static void wifi_setup();
 static std::optional<DynamicJsonDocument> LoadConfig();
 
-// Forward declarations for the three WebServer callbacks.
+// Forward declarations for the three web_settings callbacks.
 
-static void on_factory_reset(::grmcdorman::WebServer &);
-static void on_restart(::grmcdorman::WebServer &);
-static void on_save(::grmcdorman::WebServer &);
+static void on_factory_reset(::grmcdorman::WebSettings &);
+static void on_restart(::grmcdorman::WebSettings &);
+static void on_save(::grmcdorman::WebSettings &);
 
 ///////////////////////////////////////////////////////////////////////////////////
 // The WiFi settings.
@@ -57,7 +57,7 @@ static ::grmcdorman::SettingInterface::settings_list_t
 // Path to the config file
 static const char config_path[] PROGMEM = "/config.json";
 
-static grmcdorman::WebServer webServer(80);         //!< The settings web server.
+static grmcdorman::WebSettings web_settings;    //!< The settings web server. Default port (80).
 
 // Misc variables
 static bool factory_reset_next_loop = false;    //!< Set to true when a factory reset has been requested.
@@ -158,19 +158,19 @@ void setup()
     wifi_setup();
 
     // Add our one tab to the web server.
-    webServer.add_setting_set(F("WiFi"), settings);
+    web_settings.add_setting_set(F("WiFi"), settings);
 
     // Add an extra handler.
-    webServer.get_server().on("/heap", HTTP_GET, [](AsyncWebServerRequest *request){
+    web_settings.get_server().on("/heap", HTTP_GET, [](AsyncWebServerRequest *request){
         request->send(200, "text/plain", String(ESP.getFreeHeap()));
     });
 
     // Set up the web server and page.
-    webServer.setup(on_save, on_restart, on_factory_reset);
+    web_settings.setup(on_save, on_restart, on_factory_reset);
     // If we are connected to an AP, set credentials.
     if (WiFi.status() == WL_CONNECTED)
     {
-        webServer.set_credentials("admin", "password");
+        web_settings.set_credentials("admin", "password");
     }
 
     Serial.print(F("IP: "));
@@ -187,7 +187,7 @@ void loop()
     }
 
     // Not presently essential; might be needed in future.
-    webServer.loop();
+    web_settings.loop();
 
     if (factory_reset_next_loop && millis() - restart_reset_when > restart_reset_delay)
     {
@@ -332,19 +332,19 @@ static std::optional<DynamicJsonDocument> LoadConfig()
 }
 
 
-static void on_factory_reset(::grmcdorman::WebServer &)
+static void on_factory_reset(::grmcdorman::WebSettings &)
 {
     factory_reset_next_loop = true;
     restart_reset_when = millis();
 }
 
-static void on_restart(::grmcdorman::WebServer &)
+static void on_restart(::grmcdorman::WebSettings &)
 {
     restart_next_loop =-true;
     restart_reset_when = millis();
 }
 
-static void on_save(::grmcdorman::WebServer &)
+static void on_save(::grmcdorman::WebSettings &)
 {
     Serial.println("Saving settings");
     DynamicJsonDocument json(4096);

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A settings/property web page server
 paragraph=Provides a simple way of creating a tabbed setting/info web page. Supports SoftAP portal capture.
 category=Communication
 url=https://github.com/grmcdorman/esp8266_web_settings
-depends=ArduinoJson, ESP Async WebServer
+depends=ArduinoJson, https://github.com/me-no-dev/ESPAsyncWebServer.git

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A settings/property web page server
 paragraph=Provides a simple way of creating a tabbed setting/info web page. Supports SoftAP portal capture.
 category=Communication
 url=https://github.com/grmcdorman/esp8266_web_settings
-depends=ArduinoJson, https://github.com/me-no-dev/ESPAsyncWebServer.git
+depends=ArduinoJson, ESPAsyncWebServer

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,6 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 debug_port = COM3
-lib_deps = 
+lib_deps =
 	bblanchon/ArduinoJson @ ^6.18.3
-	ottowinter/ESPAsyncWebServer-esphome@^2.1.0
+	me-no-dev/ESPAsyncWebServer

--- a/src/WebSettings.cpp
+++ b/src/WebSettings.cpp
@@ -1,5 +1,5 @@
 
-#include "grmcdorman/WebServer.h"
+#include "grmcdorman/WebSettings.h"
 
 #include <AsyncJson.h>
 #include <LittleFS.h>
@@ -321,12 +321,12 @@ namespace grmcdorman
             "}";
     }
 
-    WebServer::WebServer(uint16_t port): server(port)
+    WebSettings::WebSettings(uint16_t port): server(port)
     {
         generate_new_authentication();
     }
 
-    void WebServer::setup(const notify_t &on_save_f, const notify_t &on_restart_f, const notify_t &on_factory_reset_f)
+    void WebSettings::setup(const notify_t &on_save_f, const notify_t &on_restart_f, const notify_t &on_factory_reset_f)
     {
         on_save = on_save_f;
         on_restart = on_restart_f;
@@ -477,7 +477,7 @@ namespace grmcdorman
         size += N - 1;
     }
 
-    bool WebServer::on_main_page_tabbutton_chunk(uint8_t *buffer, size_t maxLen, size_t &size, MainPageChunkContext &context)
+    bool WebSettings::on_main_page_tabbutton_chunk(uint8_t *buffer, size_t maxLen, size_t &size, MainPageChunkContext &context)
     {
         static const char button_start[] PROGMEM = "<button class=\"tablinks";
         static const char active[] PROGMEM = " active";
@@ -529,7 +529,7 @@ namespace grmcdorman
         return true;    // All done.
     }
 
-    bool WebServer::on_main_page_tabbody_chunk(uint8_t *buffer, size_t maxLen, size_t &size, MainPageChunkContext &context)
+    bool WebSettings::on_main_page_tabbody_chunk(uint8_t *buffer, size_t maxLen, size_t &size, MainPageChunkContext &context)
     {
         while (context.current_panel != setting_panels.end())
         {
@@ -625,7 +625,7 @@ namespace grmcdorman
         return true;
     }
 
-    bool WebServer::on_main_page_footer_chunk(uint8_t *buffer, size_t maxLen, size_t &size, MainPageChunkContext &context)
+    bool WebSettings::on_main_page_footer_chunk(uint8_t *buffer, size_t maxLen, size_t &size, MainPageChunkContext &context)
     {
         static const char footer_start[] PROGMEM =
                     "<input class=\"md_button ripple\" type=\"submit\" value=\"Save\">"
@@ -696,7 +696,7 @@ namespace grmcdorman
         return true;
     }
 
-    size_t WebServer::on_main_page_chunk(uint8_t *buffer, size_t maxLen, size_t , MainPageChunkContext *context_ptr)
+    size_t WebSettings::on_main_page_chunk(uint8_t *buffer, size_t maxLen, size_t , MainPageChunkContext *context_ptr)
     {
         auto & context = *context_ptr;
         size_t size(0);
@@ -766,17 +766,17 @@ namespace grmcdorman
         return size;
     }
 
-    void WebServer::add_setting_set(const __FlashStringHelper *name, const SettingInterface::settings_list_t &list)
+    void WebSettings::add_setting_set(const __FlashStringHelper *name, const SettingInterface::settings_list_t &list)
     {
         setting_panels.emplace_back(std::make_unique<SettingPanel>(name, list));
     }
 
-    void WebServer::loop()
+    void WebSettings::loop()
     {
         // Asynchronous, nothing to see here. This is not the loop you are looking for.
     }
 
-    void WebServer::on_request_upload(AsyncWebServerRequest *request)
+    void WebSettings::on_request_upload(AsyncWebServerRequest *request)
     {
         //!< @TODO This should have better styling.
         request->send(200, TEXT_HTML, F("<!DOCTYPE html>"
@@ -790,7 +790,7 @@ namespace grmcdorman
             "</form>"));
     }
 
-    void WebServer::handle_upload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final)
+    void WebSettings::handle_upload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final)
     {
         // Shamelessly adapted from tzapu/WiFiManager for Async web server
 
@@ -848,7 +848,7 @@ namespace grmcdorman
         delay(0);
     }
 
-    void WebServer::on_update_failed(AsyncWebServerRequest *request)
+    void WebSettings::on_update_failed(AsyncWebServerRequest *request)
     {
         String page = F("<!DOCTYPE html><html>"
             "<link rel=\"stylesheet\" href=\"/style.css\">"
@@ -868,7 +868,7 @@ namespace grmcdorman
         request->send(500, TEXT_HTML, page);
     }
 
-    void WebServer::on_update_done(AsyncWebServerRequest *request)
+    void WebSettings::on_update_done(AsyncWebServerRequest *request)
     {
         if (Update.hasError())
         {
@@ -891,7 +891,7 @@ namespace grmcdorman
         on_restart(*this);
     }
 
-    void WebServer::on_request_values(AsyncWebServerRequest *request)
+    void WebSettings::on_request_values(AsyncWebServerRequest *request)
     {
         if (!request->hasArg("tab"))
         {
@@ -914,7 +914,7 @@ namespace grmcdorman
         request->send(response);
     }
 
-    void WebServer::on_not_found(AsyncWebServerRequest *request)
+    void WebSettings::on_not_found(AsyncWebServerRequest *request)
     {
         // In soft AP mode redirect to the root document.
         if (WiFi.softAPgetStationNum() != 0)
@@ -932,7 +932,7 @@ namespace grmcdorman
         }
     }
 
-    void WebServer::generate_new_authentication()
+    void WebSettings::generate_new_authentication()
     {
         // Authentication realm may exclude some characters,
         // for simplicity generate using the following set.
@@ -950,7 +950,7 @@ namespace grmcdorman
         }
     }
 
-    bool WebServer::verify_authentication(AsyncWebServerRequest *request)
+    bool WebSettings::verify_authentication(AsyncWebServerRequest *request)
     {
         if (!auth_user.isEmpty())
         {

--- a/src/esp8266_web_settings.h
+++ b/src/esp8266_web_settings.h
@@ -1,6 +1,6 @@
 // This file is required by Arduino libraries, despite the risk of this colliding with other header files.
 // The author's recommendation is that you ignore this file and include the file(s) of interest
-// such as <grmcdorman/WebServer.h>.
+// such as <grmcdorman/WebSettings.h>.
 
 // Include the main file. This does not include other classes.
-#include <grmcdorman/WebServer.h>
+#include <grmcdorman/WebSettings.h>

--- a/src/grmcdorman/WebSettings.h
+++ b/src/grmcdorman/WebSettings.h
@@ -57,23 +57,23 @@ namespace grmcdorman
      */
 
     /**
-     * @brief The WebServer class.
+     * @brief The WebSettings class.
      *
      * This is the primary class for the library; it handles the web pages
      * and manages the sets of settings.
      *
      */
-    class WebServer
+    class WebSettings
     {
     public:
-        typedef void (*notify_t)(WebServer &);      //!< The callback definition.
+        typedef void (*notify_t)(WebSettings &);      //!< The callback definition.
 
         /**
          * @brief Construct a new Web Server object.
          *
          * @param port The server port; default is 80.
          */
-        explicit WebServer(uint16_t port = 80);
+        explicit WebSettings(uint16_t port = 80);
         /**
          * @brief Set up the web server.
          *


### PR DESCRIPTION
The `WebSettings` name makes more sense for the class.

Also:
 * Correct to a consistent ESPAsyncWebServer repo (main repo, not a fork).
 * Pre-commit hooks also need fixing to point to that repo.

Pre-commit compile examples still doesn't work, it can't find DNSServer.h.