### PR TITLE
v1.1.0 prep

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,8 +14,8 @@
     "type": "git",
     "url": "https://github.com/grmcdorman/esp8266_web_settings.git"
   },
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "frameworks": "arduino",
-  "platforms": "*"
+  "platforms": "esp8266"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=esp8266_web_settings
-version=1.0.1
+version=1.1.0
 author=grmcdorman
 maintainer=grmcdorman <17110555+grmcdorman@users.noreply.github.com>
 sentence=A settings/property web page server

--- a/src/grmcdorman/SettingPanel.h
+++ b/src/grmcdorman/SettingPanel.h
@@ -22,10 +22,11 @@ namespace grmcdorman
         /**
          * @brief Construct a new Setting Panel object.
          *
-         * @param name          The setting panel name. This is both the panel ID and the text on the UI tab.
+         * @param name          The setting panel name. This is used on UI elements.
+         * @param identifier    The setting panel identifier. This is used in code.
          * @param settings_set  The set of settings for the panel. Held as a reference; do not destroy.
          */
-        SettingPanel(const __FlashStringHelper *name, const SettingInterface::settings_list_t &settings_set);
+        SettingPanel(const __FlashStringHelper *name, const __FlashStringHelper *identifier, const SettingInterface::settings_list_t &settings_set);
         /**
          * @brief Handle a POST set-values request.
          *
@@ -50,10 +51,10 @@ namespace grmcdorman
          * The settings are inserted in the output document as an array under the key
          * containing the panel name.
          *
-         * @param specific_setting      If not empty, include only the specific, named setting. If the setting does not exist, return an empty array.
-         * @return JSON document containing all settings (if `specific_setting` is empty) or the single requested setting.
+         * @param requested_settings    If not empty, include only the specific, named settings. Settings that do not exist are ignored.
+         * @return JSON document containing all settings (if `specific_setting` is empty) or the requested settings that exist.
          */
-        DynamicJsonDocument as_json(const String &specific_setting) const;
+        DynamicJsonDocument as_json(const std::vector<const String *> &requested_settings) const;
         /**
          * @brief Get the panel name.
          *
@@ -76,6 +77,28 @@ namespace grmcdorman
         }
 
         /**
+         * @brief Get the panel identifier.
+         *
+         * The name is used both as a label on the UI and as an ID for incoming fields in the POST request,
+         * and for outgoing settings in the JSON.
+         * @return Panel name.
+         */
+        const __FlashStringHelper * get_identifier() const
+        {
+            return identifier;
+        }
+
+        /**
+         * @brief Get the identifier length.
+         *
+         * @return Length of the identifier, equivalent to String(get_identifier()).length() or similar.
+         */
+        size_t get_identifier_length() const
+        {
+            return identifier_length;
+        }
+
+        /**
          * @brief Get the settings list.
          *
          * @return The wrapped settings list.
@@ -87,6 +110,8 @@ namespace grmcdorman
     private:
         const __FlashStringHelper * name;                   //!< The panel name, from the constructor.
         const size_t name_length;                           //!< The length of the name string.
+        const __FlashStringHelper * identifier;             //!< The panel identifier, from the constructor.
+        const size_t identifier_length;                           //!< The length of the identifier string.
         const SettingInterface::settings_list_t &settings;  //!< The set of settings contained in the panel.
     };
 }

--- a/src/grmcdorman/WebSettings.h
+++ b/src/grmcdorman/WebSettings.h
@@ -90,6 +90,7 @@ namespace grmcdorman
          *
          */
         void loop();
+
         /**
          * @brief Add a setting set.
          *
@@ -99,10 +100,30 @@ namespace grmcdorman
          *
          * Settings can be added after `setup` is called; current pages in browsers will not be updated, however..
          *
+         * This overload will use the set name for the set identifier as well.
+         *-
          * @param name          The name for the set; also the name shown on the tab.
          * @param setting_set   The set of settings. Held as a reference; do not destroy the object passed in.
          */
-        void add_setting_set(const __FlashStringHelper *name, const SettingInterface::settings_list_t &setting_set);
+        void add_setting_set(const __FlashStringHelper *name, const SettingInterface::settings_list_t &setting_set)
+        {
+            add_setting_set(name, name, setting_set);
+        }
+
+        /**
+         * @brief Add a setting set.
+         *
+         * This registers a setting set which will be wrapped in a `SettingPanel` and presented
+         * on the main page. The first set registered will be the default set shown when the
+         * page is first loaded.
+         *
+         * Settings can be added after `setup` is called; current pages in browsers will not be updated, however..
+         *
+         * @param name          The name for the set; used for UI elements only.
+         * @param identifier    The identifier for the set; used in code.
+         * @param setting_set   The set of settings. Held as a reference; do not destroy the object passed in.
+         */
+        void add_setting_set(const __FlashStringHelper *name, const __FlashStringHelper *identifier, const SettingInterface::settings_list_t &setting_set);
 
         /**
          * @brief Get the server.
@@ -178,6 +199,10 @@ namespace grmcdorman
         //!< States for the main page chunk transmission.
         enum class MainPageChunkState {
             BEGIN_PAGE,         //!< Sending the initial portion.
+            STYLE_SHEET,        //!< Sending the style sheet body.
+            PRE_JAVASCRIPT,     //!< Closing off the style sheet, starting JavaScript.
+            JAVASCRIPT,         //!< Sending the javascript.
+            POST_JAVASCRIPT,    //!< Sending post-javascript up to the tab button header.
             TABBUTTON_HEADER,   //!< Sending the tab button header.
             TAB_BODY,           //!< Sending the tab bodies.
             FOOTER,             //!< Sending the footer.
@@ -191,9 +216,10 @@ namespace grmcdorman
             setting_panel_list_t::const_iterator current_panel;                 //!< Where applicable, the panel being processed.
             SettingInterface::settings_list_t::const_iterator current_setting;  //!< Where applicable, the setting in the panel being processed.
             bool starting_tab = true;                                           //!< If `true`, a tab body is to be started.
+            size_t sent_static_size = 0;                                        //!< For the style sheet and javascript, size sent so far.
         };
 
-        /**
+       /**
          * @brief Handle main page chunks.
          *
          * This writes each chunk into the buffer, and then returns the size written.


### PR DESCRIPTION
Changes:
* Tabs (settings sets) now have identifiers that are distinct from the name (the name being the label).
* The URL /settings/get query parameters can now explicitly request multiple settings rather than just one
* The main page includes styles and JavaScript inline; this improves performance (both memory and load) on the ESP8266.
* The response to the /settings/get has a Cache-Control: No-Cache header to prevent browsers caching the reply.
* Periodic update only updates the currently displayed tab instead of all of them.
* Tested working in Chrome, Firefox, IE 9+, Edge. (Old versions of IE are not supported).